### PR TITLE
Name the loggers after modules they annotate

### DIFF
--- a/examples/acs2/boolean_multiplexer/perform_experiment.py
+++ b/examples/acs2/boolean_multiplexer/perform_experiment.py
@@ -10,6 +10,8 @@ from lcs.agents.acs2 import ACS2, Configuration
 
 logging.basicConfig(level=logging.INFO)
 
+logger = logging.getLogger(__name__)
+
 
 def evaluate_performance(env, population, ctrl_bits):
     p1 = env.render()  # state after executing action
@@ -56,8 +58,8 @@ TRIALS = 250_000
 population, metrics = perform_experiment(*get_actors(), trials=TRIALS)
 
 # Dump data to file
-logging.info("Dumping data to files")
+logger.info("Dumping data to files")
 pickle.dump(population, open("population.p", "wb"))
 pickle.dump(metrics, open("metrics.p", "wb"))
 
-logging.info("Experiment completed")
+logger.info("Experiment completed")

--- a/examples/acs2/go/acs2_in_go.py
+++ b/examples/acs2/go/acs2_in_go.py
@@ -14,6 +14,9 @@ logging.basicConfig(
     filemode='w'
 )
 
+logger = logging.getLogger(__name__)
+
+
 if __name__ == '__main__':
     env = gym.make('Go9x9-v0')  # TODO: removed from GYM after 0.9 :(
     state = env.reset()
@@ -36,15 +39,15 @@ if __name__ == '__main__':
         do_ga=True
     )
 
-    logging.info(cfg)
+    logger.info(cfg)
 
     # Create the agent
     agent = ACS2(cfg)
     population, metrics = agent.explore_exploit(env, 50)
 
     # Store metrics in file
-    logging.info("Dumping data to files ...")
+    logger.info("Dumping data to files ...")
     pickle.dump(population, open("go_population.pkl", "wb"))
     pickle.dump(metrics, open("go_metrics.pkl", "wb"))
 
-    logging.info("Done")
+    logger.info("Done")

--- a/examples/acs2/go_self_play/environment/go_board.py
+++ b/examples/acs2/go_self_play/environment/go_board.py
@@ -4,6 +4,9 @@ from .go_naive import Position, IllegalMove
 from .go_naive import WHITE, swap_colors
 
 
+logger = logging.getLogger(__name__)
+
+
 class GoBoard:
     """
     Class mimic OpenAI Gym Environment interface but enables ACS2 to play
@@ -15,7 +18,7 @@ class GoBoard:
         self.moves = 0
 
     def reset(self):
-        logging.debug("Resetting Go board state")
+        logger.debug("Resetting Go board state")
         self.pos = Position.initial_state()
         self.color = None
         self.moves = 0
@@ -25,7 +28,7 @@ class GoBoard:
         reward = 0
         done = False
         self._distinguish_player_color()
-        logging.debug("[{}] moves to [{}]".format(self.color, action))
+        logger.debug("[{}] moves to [{}]".format(self.color, action))
 
         try:
             self.pos = self.pos.play_move(action, self.color)
@@ -35,7 +38,7 @@ class GoBoard:
                 done = True
 
         except IllegalMove:
-            # logging.error("Illegal move exception, finishing trial")
+            # logger.error("Illegal move exception, finishing trial")
             reward = -1
             done = True
 

--- a/examples/acs2/maze/acs2_in_maze.py
+++ b/examples/acs2/maze/acs2_in_maze.py
@@ -10,6 +10,8 @@ from lcs.agents.acs2 import ACS2, Configuration
 # Configure logger
 logging.basicConfig(level=logging.INFO)
 
+logger = logging.getLogger("integration")
+
 
 if __name__ == '__main__':
 
@@ -21,7 +23,7 @@ if __name__ == '__main__':
                         epsilon=1.0,
                         do_ga=False,
                         performance_fcn=calculate_performance)
-    logging.info(cfg)
+    logger.info(cfg)
 
     # Explore the environment
     agent = ACS2(cfg)
@@ -32,4 +34,4 @@ if __name__ == '__main__':
     population, exploit_metric = agent.exploit(maze, 10)
 
     for metric in exploit_metric:
-        logging.info(metric)
+        logger.info(metric)

--- a/lcs/agents/acs2/ACS2.py
+++ b/lcs/agents/acs2/ACS2.py
@@ -8,6 +8,9 @@ from ...strategies.action_selection import choose_action
 from ...utils import parse_state
 
 
+logger = logging.getLogger(__name__)
+
+
 class ACS2(Agent):
     def __init__(self,
                  cfg: Configuration,
@@ -72,7 +75,7 @@ class ACS2(Agent):
 
             trial_metrics = self._collect_metrics(
                 env, current_trial, steps_in_trial, steps)
-            logging.info(trial_metrics)
+            logger.info(trial_metrics)
             metrics.append(trial_metrics)
 
             current_trial += 1
@@ -80,7 +83,7 @@ class ACS2(Agent):
         return self.population, metrics
 
     def _run_trial_explore(self, env, time, current_trial=None):
-        logging.debug("** Running trial explore ** ")
+        logger.debug("** Running trial explore ** ")
         # Initial conditions
         steps = 0
         raw_state = env.reset()
@@ -114,7 +117,7 @@ class ACS2(Agent):
                         state)
 
             action = choose_action(match_set, self.cfg.epsilon)
-            logging.debug("\tExecuting action: [%d]", action)
+            logger.debug("\tExecuting action: [%d]", action)
             action_set = match_set.form_action_set(action, self.cfg)
 
             prev_state = state
@@ -144,7 +147,7 @@ class ACS2(Agent):
         return steps
 
     def _run_trial_exploit(self, env, time=None, current_trial=None):
-        logging.debug("** Running trial exploit **")
+        logger.debug("** Running trial exploit **")
         # Initial conditions
         steps = 0
         raw_state = env.reset()

--- a/lcs/agents/racs/RACS.py
+++ b/lcs/agents/racs/RACS.py
@@ -98,7 +98,7 @@ class RACS(Agent):
                 self.cfg.number_of_possible_actions,
                 self.cfg.epsilon)
             internal_action = parse_action(action, self.cfg.action_mapping_fcn)
-            logging.debug("\tExecuting action: [%d]", action)
+            logger.debug("\tExecuting action: [%d]", action)
             action_set = match_set.form_action_set(action)
 
             prev_state = state

--- a/lcs/agents/racs/RACS.py
+++ b/lcs/agents/racs/RACS.py
@@ -7,6 +7,9 @@ from ...agents.racs import Configuration, ClassifierList
 from ...utils import parse_state
 
 
+logger = logging.getLogger(__name__)
+
+
 class RACS(Agent):
     """ACS2 agent operating on real-valued (floating) number"""
 
@@ -23,7 +26,7 @@ class RACS(Agent):
         pass
 
     def _run_trial_explore(self, env, time):
-        logging.debug("** Running trial explore ** ")
+        logger.debug("** Running trial explore ** ")
         # Initial conditions
         steps = 0
         raw_state = env.reset()

--- a/lcs/strategies/action_selection.py
+++ b/lcs/strategies/action_selection.py
@@ -7,6 +7,9 @@ from typing import Optional
 from lcs.agents.acs2 import Classifier, ClassifiersList
 
 
+logger = logging.getLogger(__name__)
+
+
 def choose_action(cll, epsilon: float) -> Optional[int]:
     """
     Chooses which action to execute given classifier list (match set).
@@ -24,10 +27,10 @@ def choose_action(cll, epsilon: float) -> Optional[int]:
         number of chosen action
     """
     if random() < epsilon:
-        logging.debug("\t\tExploration path")
+        logger.debug("\t\tExploration path")
         return explore(cll)
 
-    logging.debug("\t\tExploitation path")
+    logger.debug("\t\tExploitation path")
     return exploit(cll)
 
 


### PR DESCRIPTION
This way instead of
  `DEBUG:root:...`
we get for instance
  `DEBUG:lcs.strategies.action_selection:...`
which allows for easier filtering of messages.