### PR TITLE
Assertion about wildcard

### DIFF
--- a/lcs/agents/PerceptionString.py
+++ b/lcs/agents/PerceptionString.py
@@ -10,6 +10,7 @@ class PerceptionString(TypedList):
 
     def __init__(self, observation, wildcard='#', oktypes=(str,)):
         super().__init__(oktypes, *observation)
+        assert isinstance(wildcard, str)
         self.wildcard = wildcard
 
     @classmethod


### PR DESCRIPTION
As you can see, this assertion fails while it shouldn't. Running
```
py.test -n 4 --cov=lcs tests/lcs/agents/acs2
```
shows that, unexpectedly `wildcard = <lcs.agents.acs2.Configuration.Configuration object at 0x7f86e315e828>`

Attaching the log for details:
[log.txt](https://github.com/ParrotPrediction/pyalcs/files/2501297/log.txt)

I suggest that you fix this and then merge the assertion.