### PR TITLE
Introduce EnvironmentAdapter in place of action and state mapper functions

### DIFF
--- a/examples/acs2/boolean_multiplexer/acs2_in_multiplexer.py
+++ b/examples/acs2/boolean_multiplexer/acs2_in_multiplexer.py
@@ -3,11 +3,13 @@ import gym
 import gym_multiplexer
 
 from examples.acs2.boolean_multiplexer.utils import calculate_performance
-from lcs.agents.acs2 import ACS2, Configuration
+from lcs.agents.acs2 import ACS2, Configuration, EnvironmentAdapter
 
 
-def _map_perception(perception):
-    return [str(x) for x in perception]
+class MultiplexerAdapter(EnvironmentAdapter):
+    @staticmethod
+    def env_state_to_acs(env_state):
+        return [str(x) for x in env_state]
 
 
 if __name__ == '__main__':
@@ -17,7 +19,7 @@ if __name__ == '__main__':
     # Create agent
     cfg = Configuration(mp.env.observation_space.n, 2,
                         do_ga=False,
-                        perception_mapper_fcn=_map_perception,
+                        environment_adapter=MultiplexerAdapter(),
                         performance_fcn=calculate_performance,
                         performance_fcn_params={'ctrl_bits': 2})
     agent = ACS2(cfg)

--- a/lcs/agents/acs2/ACS2.py
+++ b/lcs/agents/acs2/ACS2.py
@@ -8,7 +8,6 @@ from . import ClassifiersList, Configuration
 from ...agents import Agent
 from ...agents.Agent import Metric
 from ...strategies.action_selection import choose_action
-from ...utils import parse_state, parse_action
 from typing import Tuple
 
 logger = logging.getLogger(__name__)
@@ -103,7 +102,7 @@ class ACS2(Agent):
         # Initial conditions
         steps = 0
         raw_state = env.reset()
-        state = parse_state(raw_state, self.cfg.perception_mapper_fcn)
+        state = self.cfg.environment_adapter.env_state_to_acs(raw_state)
         action = None
         reward = None
         prev_state = None
@@ -159,13 +158,13 @@ class ACS2(Agent):
                 match_set,
                 self.cfg.number_of_possible_actions,
                 self.cfg.epsilon)
-            internal_action = parse_action(action, self.cfg.action_mapping_fcn)
+            internal_action = self.cfg.environment_adapter.acs_action_to_env(action)
             logger.debug("\tExecuting action: [%d]", action)
             action_set = match_set.form_action_set(action)
 
             prev_state = state
             raw_state, reward, done, _ = env.step(internal_action)
-            state = parse_state(raw_state, self.cfg.perception_mapper_fcn)
+            state = self.cfg.environment_adapter.env_state_to_acs(raw_state)
 
             if done:
                 ClassifiersList.apply_alp(
@@ -207,7 +206,7 @@ class ACS2(Agent):
         # Initial conditions
         steps = 0
         raw_state = env.reset()
-        state = parse_state(raw_state, self.cfg.perception_mapper_fcn)
+        state = self.cfg.environment_adapter.env_state_to_acs(raw_state)
 
         reward = None
         action_set = ClassifiersList()
@@ -229,11 +228,11 @@ class ACS2(Agent):
                 match_set,
                 self.cfg.number_of_possible_actions,
                 epsilon=0.0)
-            internal_action = parse_action(action, self.cfg.action_mapping_fcn)
+            internal_action = self.cfg.environment_adapter.acs_action_to_env(action)
             action_set = match_set.form_action_set(action)
 
             raw_state, reward, done, _ = env.step(internal_action)
-            state = parse_state(raw_state, self.cfg.perception_mapper_fcn)
+            state = self.cfg.environment_adapter.env_state_to_acs(raw_state)
 
             if done:
                 ClassifiersList.apply_reinforcement_learning(
@@ -330,9 +329,10 @@ class ACS2(Agent):
                 action = act
                 action_set = ClassifiersList.form_action_set(match_set, action)
 
-                raw_state, reward, done, _ = env.step(parse_action(action))
+                internal_action = self.cfg.environment_adapter.acs_action_to_env(action)
+                raw_state, reward, done, _ = env.step(internal_action)
                 prev_state = state
-                state = parse_state(raw_state)
+                state = self.cfg.environment_adapter.env_state_to_acs(raw_state)
 
                 if not exists_classifier(action_set, Perception(prev_state),
                                          action, Perception(state),

--- a/lcs/agents/acs2/Configuration.py
+++ b/lcs/agents/acs2/Configuration.py
@@ -1,10 +1,12 @@
+from .EnvironmentAdapter import EnvironmentAdapter
+
+
 class Configuration:
     def __init__(self,
                  classifier_length,
                  number_of_possible_actions,
                  classifier_wildcard='#',
-                 perception_mapper_fcn=None,
-                 action_mapping_fcn=None,
+                 environment_adapter=EnvironmentAdapter,
                  environment_metrics_fcn=None,
                  performance_fcn=None,
                  performance_fcn_params={},
@@ -30,8 +32,8 @@ class Configuration:
         :param number_of_possible_actions: number of possible actions to
             be executed
         :param classifier_wildcard: wildcard symbol
-        :param perception_mapper_fcn:
-        :param action_mapping_fcn:
+        :param environment_adapter: EnvironmentAdapter class ACS2 needs to use
+            to interact with the environment
         :param environment_metrics_fcn:
         :param performance_fcn: function for estimating agent performance
         :param performance_fcn_params: optional parameters needed for
@@ -57,8 +59,7 @@ class Configuration:
         self.classifier_length = classifier_length
         self.number_of_possible_actions = number_of_possible_actions
         self.classifier_wildcard = classifier_wildcard
-        self.perception_mapper_fcn = perception_mapper_fcn
-        self.action_mapping_fcn = action_mapping_fcn
+        self.environment_adapter = environment_adapter
         self.environment_metrics_fcn = environment_metrics_fcn
         self.performance_fcn = performance_fcn
         self.performance_fcn_params = performance_fcn_params
@@ -83,8 +84,7 @@ class Configuration:
                "\n\t- Classifier length: [{}]" \
                "\n\t- Number of possible actions: [{}]" \
                "\n\t- Classifier wildcard: [{}]" \
-               "\n\t- Perception mapper function: [{}]" \
-               "\n\t- Action mapping function: [{}]" \
+               "\n\t- Environment adapter: [{}]" \
                "\n\t- Environment metrics function: [{}]" \
                "\n\t- Performance calculation function: [{}] " \
                "\n\t- Do GA: [{}]" \
@@ -97,8 +97,7 @@ class Configuration:
             .format(self.classifier_length,
                     self.number_of_possible_actions,
                     self.classifier_wildcard,
-                    self.perception_mapper_fcn,
-                    self.action_mapping_fcn,
+                    self.environment_adapter,
                     self.environment_metrics_fcn,
                     self.performance_fcn,
                     self.do_ga,

--- a/lcs/agents/acs2/EnvironmentAdapter.py
+++ b/lcs/agents/acs2/EnvironmentAdapter.py
@@ -1,15 +1,15 @@
 class EnvironmentAdapter:
     """
     Sometimes the observation returned by the OpenAI Gym environment
-    does not suit the observation representation as used by the ACS2.
-    In that case there's a need for converter functions that map the ACS2
+    does not suit the observation representation as used by the LCS.
+    In that case there's a need for converter functions that map the LCS
     representation to the environment representation and vice versa.
 
     The same goes for action representation.
 
     This class realizes this conversion.
 
-    This implementation works for environments which provide ACS2-compatible
+    This implementation works for environments which provide LCS-compatible
     state and action representations (no conversion needed).
 
     Subclass this class in pyALCS integration to provide an adapter
@@ -17,33 +17,33 @@ class EnvironmentAdapter:
     """
 
     @staticmethod
-    def env_action_to_acs(env_action):
+    def to_lcs_action(env_action):
         """
-        Converts environment representation of an action to ACS2
+        Converts environment representation of an action to LCS
         representation.
         """
         return env_action
 
     @staticmethod
-    def env_state_to_acs(env_state):
+    def to_genotype(phenotype):
         """
-        Converts environment representation of a state to ACS2
+        Converts environment representation of a state to LCS
         representation.
         """
-        return env_state
+        return phenotype
 
     @staticmethod
-    def acs_action_to_env(acs_action):
+    def to_env_action(lcs_action):
         """
-        Converts ACS2 representation of an action to environment
+        Converts LCS representation of an action to environment
         representation.
         """
-        return acs_action
+        return lcs_action
 
     @staticmethod
-    def acs_state_to_env(acs_state):
+    def to_phenotype(genotype):
         """
-        Converts ACS2 representation of a state to environment
+        Converts LCS representation of a state to environment
         representation.
         """
-        return acs_state
+        return genotype

--- a/lcs/agents/acs2/EnvironmentAdapter.py
+++ b/lcs/agents/acs2/EnvironmentAdapter.py
@@ -1,0 +1,49 @@
+class EnvironmentAdapter:
+    """
+    Sometimes the observation returned by the OpenAI Gym environment
+    does not suit the observation representation as used by the ACS2.
+    In that case there's a need for converter functions that map the ACS2
+    representation to the environment representation and vice versa.
+
+    The same goes for action representation.
+
+    This class realizes this conversion.
+
+    This implementation works for environments which provide ACS2-compatible
+    state and action representations (no conversion needed).
+
+    Subclass this class in pyALCS integration to provide an adapter
+    for a specific environment.
+    """
+
+    @staticmethod
+    def env_action_to_acs(env_action):
+        """
+        Converts environment representation of an action to ACS2
+        representation.
+        """
+        return env_action
+
+    @staticmethod
+    def env_state_to_acs(env_state):
+        """
+        Converts environment representation of a state to ACS2
+        representation.
+        """
+        return env_state
+
+    @staticmethod
+    def acs_action_to_env(acs_action):
+        """
+        Converts ACS2 representation of an action to environment
+        representation.
+        """
+        return acs_action
+
+    @staticmethod
+    def acs_state_to_env(acs_state):
+        """
+        Converts ACS2 representation of a state to environment
+        representation.
+        """
+        return acs_state

--- a/lcs/agents/acs2/__init__.py
+++ b/lcs/agents/acs2/__init__.py
@@ -1,4 +1,5 @@
 from .Configuration import Configuration
+from .EnvironmentAdapter import EnvironmentAdapter
 from .Condition import Condition
 from .Effect import Effect
 from .PMark import PMark

--- a/tests/integration/acs2/test_Multiplexer.py
+++ b/tests/integration/acs2/test_Multiplexer.py
@@ -4,12 +4,14 @@ import gym_multiplexer
 import pytest
 
 from examples.acs2.boolean_multiplexer.utils import calculate_performance
-from lcs.agents.acs2 import ACS2, Configuration
+from lcs.agents.acs2 import ACS2, Configuration, EnvironmentAdapter
 from .utils import count_macroclassifiers, count_microclassifiers
 
 
-def _map_perception(perception):
-    return [str(x) for x in perception]
+class MultiplexerAdapter(EnvironmentAdapter):
+    @staticmethod
+    def env_state_to_acs(env_state):
+        return [str(x) for x in env_state]
 
 
 class TestMultiplexer:
@@ -24,7 +26,7 @@ class TestMultiplexer:
     def test_should_be_no_duplicated_classifiers_without_ga(self, mp):
         # given
         cfg = Configuration(mp.env.observation_space.n, 2,
-                            perception_mapper_fcn=_map_perception,
+                            environment_adapter=MultiplexerAdapter(),
                             do_ga=False)
         agent = ACS2(cfg)
 
@@ -37,7 +39,7 @@ class TestMultiplexer:
     def test_should_be_no_duplicated_classifiers_with_ga(self, mp):
         # given
         cfg = Configuration(mp.env.observation_space.n, 2,
-                            perception_mapper_fcn=_map_perception,
+                            environment_adapter=MultiplexerAdapter(),
                             do_ga=True)
         agent = ACS2(cfg)
 
@@ -53,7 +55,7 @@ class TestMultiplexer:
         # given
         cfg = Configuration(mp.env.observation_space.n, 2,
                             do_ga=False,
-                            perception_mapper_fcn=_map_perception,
+                            environment_adapter=MultiplexerAdapter(),
                             performance_fcn=calculate_performance,
                             performance_fcn_params={'ctrl_bits': 2})
         agent = ACS2(cfg)


### PR DESCRIPTION
We already had action and state conversion functions for conversions
between the environment representation and the ACS2 representation.
Whenever the environment representation of actions or states was
incompatible with what ACS2 received and produced, adapter functions
needed to be used.

However, we only had uni-directional converters:
  * env state -> ACS2 state
  * ACS2 action -> env action

The goal of this commit is to add the reverse converters, i.e.:
  * env action -> ACS2 action
  * ACS2 state -> env state
so that, e.g., `Classifier.__str__()` can be implemented properly.

For instance, this allows `Classifier.__str__()` to print `N`, `W`, `SE`,
etc. in the action part instead of `0`, `6`, `3`, etc. if the proper
environment adapter is provided.

Notebooks not updated (yet).

RACS not touched.