### PR TITLE
to_env_action() here instead of to_acs_action()

### DIFF
--- a/lcs/agents/acs2/ACS2.py
+++ b/lcs/agents/acs2/ACS2.py
@@ -161,7 +161,7 @@ class ACS2(Agent):
                 match_set,
                 self.cfg.number_of_possible_actions,
                 epsilon=0.0)
-            iaction = self.cfg.environment_adapter.to_lcs_action(action)
+            iaction = self.cfg.environment_adapter.to_env_action(action)
             action_set = match_set.form_action_set(action)
 
             raw_state, reward, done, _ = env.step(iaction)


### PR DESCRIPTION
You probably made a small mistake in this commit:
https://github.com/ParrotPrediction/pyalcs/commit/0a755740d827d4bb3c93801d07033ab1cc957fff#diff-7910cc855c75420a1042cb3ef182fcf2R92

It should have been to_env_action(), not the other way round.