### PR TITLE
Return Perception instead of a pure list in the default implementation of to_genotype()

### DIFF
--- a/lcs/agents/EnvironmentAdapter.py
+++ b/lcs/agents/EnvironmentAdapter.py
@@ -1,3 +1,6 @@
+from lcs import Perception
+
+
 class EnvironmentAdapter:
     """
     Sometimes the observation returned by the OpenAI Gym environment
@@ -30,7 +33,7 @@ class EnvironmentAdapter:
         Converts environment representation of a state to LCS
         representation.
         """
-        return phenotype
+        return Perception(phenotype)
 
     @staticmethod
     def to_env_action(lcs_action):


### PR DESCRIPTION
With this, "State: {}".format(state), prints "State: 1101",
without this "State: ('1', '1', '0', '1')". This also affects
the way the debugger prints values while stepping through
code, which is nice.