### PR TITLE
Note about reward metric

### DIFF
--- a/lcs/agents/acs2/ACS2.py
+++ b/lcs/agents/acs2/ACS2.py
@@ -44,7 +44,8 @@ class ACS2(Agent):
             if self.cfg.do_action_planning and \
                     self._time_for_action_planning(steps + time):
                 # Action Planning for increased model learning
-                steps_ap, state, prev_state, action_set, action, last_reward = \
+                steps_ap, state, prev_state, action_set, \
+                    action, last_reward = \
                     self._run_action_planning(env, steps + time, state,
                                               prev_state, action_set, action,
                                               last_reward)
@@ -183,7 +184,9 @@ class ACS2(Agent):
                              action_set: ClassifiersList,
                              action: int,
                              last_reward: int) -> Tuple[int, Perception,
-                                        Perception, ClassifiersList, int, int]:
+                                                        Perception,
+                                                        ClassifiersList,
+                                                        int, int]:
         """
         Executes action planning for model learning speed up.
         Method requests goals from 'goal generator' provided by

--- a/lcs/agents/acs2/ACS2.py
+++ b/lcs/agents/acs2/ACS2.py
@@ -130,6 +130,7 @@ class ACS2(Agent):
 
             steps += 1
 
+        # Reward is not accumulated; only last step reward is returned
         return TrialMetrics(steps, reward)
 
     def _run_trial_exploit(self, env, time=None, current_trial=None) \


### PR DESCRIPTION
Reward is not accumulated; only last step reward is returned.

Not sure if this is expected. If the the reward from each step should be accumulated instead and the returned value should be the sum of all step rewards, we'll need to also fix it. (I don't remember now if OpenAI Gym envs are allowed to return non-zero reward in the middle of an episode at all)